### PR TITLE
publish main page to /main

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -25,6 +25,7 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: .
+          destination_dir: main
           # keep_files must stay true so PR preview subdirectories
           # (pr-previews/pr-*/) are not deleted on each main-branch deploy.
           keep_files: true

--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -21,11 +21,11 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Deploy to GitHub Pages
-        uses: peaceiris/actions-gh-pages@v3
+        uses: peaceiris/actions-gh-pages@v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: .
           # keep_files must stay true so PR preview subdirectories
           # (pr-previews/pr-*/) are not deleted on each main-branch deploy.
           keep_files: true
-          exclude_assets: '.github,.git,.gitignore,.gitattributes,.squad,.copilot,package.json,prompt.txt,CLAUDE.md'
+          exclude_assets: 'pr-previews,.github,.git,.gitignore,.gitattributes,.squad,.copilot,package.json,prompt.txt,CLAUDE.md'

--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -29,4 +29,4 @@ jobs:
           # keep_files must stay true so PR preview subdirectories
           # (pr-previews/pr-*/) are not deleted on each main-branch deploy.
           keep_files: true
-          exclude_assets: 'pr-previews,.github,.git,.gitignore,.gitattributes,.squad,.copilot,package.json,prompt.txt,CLAUDE.md'
+          exclude_assets: '.github,.git,.gitignore,.gitattributes,.squad,.copilot,package.json,prompt.txt,CLAUDE.md'

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -18,7 +18,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Deploy PR preview
-        uses: peaceiris/actions-gh-pages@v3
+        uses: peaceiris/actions-gh-pages@v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: .


### PR DESCRIPTION
In this settings, error when set the `destination_dir` to default `.`

```yml
      - name: Deploy to GitHub Pages
        uses: peaceiris/actions-gh-pages@v4
        with:
          github_token: ${{ secrets.GITHUB_TOKEN }}
          publish_dir: .
          destination_dir: main
          # keep_files must stay true so PR preview subdirectories
          # (pr-previews/pr-*/) are not deleted on each main-branch deploy.
          keep_files: true
          exclude_assets: '.github,.git,.gitignore,.gitattributes,.squad,.copilot,package.json,prompt.txt,CLAUDE.md'
```